### PR TITLE
feat: レスポンシブ対応とデバイス詳細ページの追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+language: "ja-JP"
+tone_instructions: "簡潔で丁寧な日本語でレビューしてください。指摘は理由と具体的な修正案をセットで示してください。"
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  collapse_walkthrough: true
+  poem: false
+
+  # drizzle-kit の生成物やビルド成果物はレビュー対象外
+  path_filters:
+    - "!worker/migrations/**"
+    - "!worker/dist/**"
+    - "!**/package-lock.json"
+    - "!worker/worker-configuration.d.ts"
+
+  path_instructions:
+    - path: "worker/src/**/*.{ts,tsx}"
+      instructions: |
+        - TypeScript strict mode 前提。型アサーション（as）ではなく型ガードで絞り込むこと。
+        - DB アクセスは services/ 層に置く。ルートハンドラから直接 drizzle を叩いていたら指摘する。
+        - Cloudflare Workers は V8 Isolate 上で動くため Node.js API は使えない。
+        - 環境変数は CloudflareBindings 型経由でアクセスする。シークレットをコードに直書きしない。
+    - path: "worker/src/client/**/*.tsx"
+      instructions: |
+        - React ではなく hono/jsx。属性は className ではなく class を使う。
+        - スタイルは Tailwind CSS v4 + daisyUI。色は base-100 / base-content などの
+          daisyUI セマンティックトークンを使い、gray-900 のようなハードコードは避ける。
+        - Tailwind v4 はソース中のリテラルしかクラス名として検出しないため、
+          `badge-${status}` のような文字列組み立ては動作しない。
+        - モバイル（375px 幅）で横スクロールが発生しないこと。
+    - path: "worker/src/**/*.test.ts"
+      instructions: |
+        - Vitest + @cloudflare/vitest-pool-workers。cloudflare:test の env を使い、
+          サブアプリを直接 request する既存の書き方に合わせる。
+        - テスト間でストレージが共有され seed データも存在するため、
+          デバイス名は `Test Device ${Date.now()}` のように一意にする。
+        - レスポンスの検証はキャストではなく手書きの型ガードで行う。
+    - path: "worker/src/db/schema.ts"
+      instructions: |
+        - スキーマ変更時は drizzle-kit generate によるマイグレーション生成が必要。
+          マイグレーションファイルが伴っていなければ指摘する。
+        - 外部キーには onDelete: "cascade" を設定する。
+    - path: "arduino/**/*.{ino,cpp,h}"
+      instructions: |
+        - Arduino UNO R4 WiFi 向け。WiFi 接続には自動再接続を実装する。
+        - シークレットは secrets.h に置き、Git 管理下に含めない。
+        - エラー時は LED マトリクスで視覚的にフィードバックする。
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+
+  tools:
+    eslint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+
+chat:
+  auto_reply: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Arduino UNO R4 WiFi と Cloudflare Workers を使用したハートビートモ�
 
 ### Frontend
 - **Framework**: Hono JSX
-- **Styling**: Tailwind CSS v4
+- **Styling**: Tailwind CSS v4 + daisyUI v5（`src/style.css` の `@plugin "daisyui"` で設定、light テーマのみ）
 - **Build**: Vite
 
 ### Device (Arduino)
@@ -162,8 +162,20 @@ pio device monitor   # シリアルモニター起動
 ### GET/POST /api/devices
 デバイスの一覧取得・登録
 
+### GET /api/devices/reports
+全デバイスとそのレポート（ステータス変化履歴）を取得する
+
+**Query Parameters:**
+- `limit`: デバイスごとに返すレポートの最大件数（1〜100、省略時は全件）
+
+### GET /api/reports/:device
+指定デバイスのレポートを新しい順に全件取得する
+
 ### GET /
-Web ダッシュボード（全デバイスのステータス表示）
+Web ダッシュボード（全デバイスのステータス一覧 + デバイスごとの最新レポート5件）
+
+### GET /devices/:device
+デバイス詳細ページ（ステータス概要 + レポート全件）。未登録のデバイス名は 404 を返す。
 
 ## 環境変数
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Arduino UNO R4 WiFi と Cloudflare Workers を使用したハートビートモ�
 
 - ハートビート受信とステータス監視（ok / warn / error / pending）
 - ステータス変更時のレポート記録とDiscord通知
-- Webダッシュボードでの状態確認
+- Webダッシュボードでの状態確認（モバイル対応）
+- デバイス詳細ページでのステータス履歴の確認
 
 ## システム構成
 
@@ -35,7 +36,7 @@ Arduino UNO R4 WiFi と Cloudflare Workers を使用したハートビートモ�
 
 - **Backend**: Cloudflare Workers + Hono v4 + Drizzle ORM
 - **Database**: Cloudflare D1 (SQLite)
-- **Frontend**: Hono JSX + Vite + Tailwind CSS
+- **Frontend**: Hono JSX + Vite + Tailwind CSS v4 + daisyUI v5
 - **Device**: Arduino UNO R4 WiFi (PlatformIO)
 
 ## 使い方
@@ -97,7 +98,7 @@ npm run dev
 ### デバイスの登録
 
 ```bash
-curl -X POST https://your-worker.workers.dev/api/locations/ \
+curl -X POST https://your-worker.workers.dev/api/devices \
   -H "Content-Type: application/json" \
   -d '{"name": "Arduino-Device-1"}'
 ```
@@ -112,7 +113,23 @@ curl -X POST https://your-worker.workers.dev/api/heartbeat \
 
 ### ダッシュボード
 
-ブラウザで `https://your-worker.workers.dev/` にアクセス
+ブラウザで `https://your-worker.workers.dev/` にアクセスします。
+
+- **トップページ**: 全デバイスのステータス一覧と、デバイスごとの最新レポート5件
+- **デバイス詳細**: `/devices/<デバイス名>` でステータス概要とレポート全件を表示。トップページのカードや「すべて見る」リンクから遷移できます
+
+### API エンドポイント
+
+| メソッド | パス | 説明 |
+| --- | --- | --- |
+| `POST` | `/api/heartbeat` | ハートビートを受信する |
+| `GET` / `POST` | `/api/devices` | デバイスの一覧取得・登録 |
+| `PUT` / `DELETE` | `/api/devices/:name` | デバイスの更新・削除 |
+| `GET` | `/api/devices/reports` | 全デバイスとそのレポートを取得（`?limit=` でデバイスごとの件数を制限） |
+| `GET` | `/api/reports` | 全レポートを新しい順に取得 |
+| `GET` | `/api/reports/:device` | 指定デバイスのレポートを新しい順に取得 |
+| `GET` | `/api/status` | 全デバイスのステータスを取得 |
+| `GET` | `/api/status/:device` | 指定デバイスのステータスを取得 |
 
 ## Arduino デバイスのセットアップ
 

--- a/worker/.prettierignore
+++ b/worker/.prettierignore
@@ -1,0 +1,6 @@
+# drizzle-kit が生成・管理するため整形しない
+migrations/
+
+dist/
+.wrangler/
+worker-configuration.d.ts

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -24,6 +24,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.0.3",
         "better-sqlite3": "^12.5.0",
+        "daisyui": "^5.7.8",
         "drizzle-kit": "^0.31.8",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -3592,6 +3593,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.7.8",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.7.8.tgz",
+      "integrity": "sha512-/r3QoXteCOSlbvUM7bfOTIkc3rq6WskDRKgdTIF7M3ufdnY8gXsAo/CfRUNM2La21Kpnr34PGyU3uDFJ6sGJog==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/debug": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -39,6 +39,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.0.3",
     "better-sqlite3": "^12.5.0",
+    "daisyui": "^5.7.8",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/worker/src/app/api/devices.test.ts
+++ b/worker/src/app/api/devices.test.ts
@@ -1,6 +1,63 @@
 import { env } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
 import { describe, it, expect } from "vitest";
+
+import * as schema from "../../db/schema";
 import devices from "./devices";
+
+interface DeviceWithReportsResponse {
+  id: number;
+  name: string;
+  reports: { id: number; status: string; createdAt: string }[];
+}
+
+// Array.isArray は unknown を any[] に絞ってしまうため、専用のガードを使う
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function isDeviceWithReportsResponse(
+  value: unknown,
+): value is DeviceWithReportsResponse {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "id" in value &&
+    typeof (value as { id?: unknown }).id === "number" &&
+    "name" in value &&
+    typeof (value as { name?: unknown }).name === "string" &&
+    "reports" in value &&
+    Array.isArray((value as { reports?: unknown }).reports)
+  );
+}
+
+/** レポート3件を持つデバイスを作成し、その名前を返す */
+async function seedDeviceWithReports(): Promise<string> {
+  const db = drizzle(env.DB, { schema });
+  const name = `Report Limit Device ${String(Date.now())}`;
+  const [device] = await db.insert(schema.devices).values({ name }).returning();
+
+  const base = Date.now();
+  await db.insert(schema.reports).values([
+    {
+      deviceId: device.id,
+      status: "ok",
+      createdAt: new Date(base).toISOString(),
+    },
+    {
+      deviceId: device.id,
+      status: "warn",
+      createdAt: new Date(base - 60_000).toISOString(),
+    },
+    {
+      deviceId: device.id,
+      status: "error",
+      createdAt: new Date(base - 120_000).toISOString(),
+    },
+  ]);
+
+  return name;
+}
 
 describe("Devices API", () => {
   describe("GET /", () => {
@@ -15,6 +72,93 @@ describe("Devices API", () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(Array.isArray(json)).toBe(true);
+    });
+  });
+
+  describe("GET /reports", () => {
+    it("should limit reports per device when limit is given", async () => {
+      const name = await seedDeviceWithReports();
+
+      const res = await devices.request(
+        "/reports?limit=2",
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const json: unknown = await res.json();
+      if (!isUnknownArray(json)) {
+        expect.fail("expected an array");
+      }
+      const target = json.find(
+        (d) => isDeviceWithReportsResponse(d) && d.name === name,
+      );
+      if (!isDeviceWithReportsResponse(target)) {
+        expect.fail("seeded device not found in response");
+      }
+
+      expect(target.reports).toHaveLength(2);
+      // createdAt の降順（新しい順）で切り取られていること
+      expect(target.reports.map((r) => r.status)).toEqual(["ok", "warn"]);
+    });
+
+    it("should return all reports when limit is omitted", async () => {
+      const name = await seedDeviceWithReports();
+
+      const res = await devices.request("/reports", { method: "GET" }, env);
+      expect(res.status).toBe(200);
+
+      const json: unknown = await res.json();
+      if (!isUnknownArray(json)) {
+        expect.fail("expected an array");
+      }
+      const target = json.find(
+        (d) => isDeviceWithReportsResponse(d) && d.name === name,
+      );
+      if (!isDeviceWithReportsResponse(target)) {
+        expect.fail("seeded device not found in response");
+      }
+
+      expect(target.reports).toHaveLength(3);
+    });
+
+    it("should apply the limit per device, not globally", async () => {
+      await seedDeviceWithReports();
+
+      const res = await devices.request(
+        "/reports?limit=1",
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const json: unknown = await res.json();
+      if (!isUnknownArray(json)) {
+        expect.fail("expected an array");
+      }
+      expect(json.length).toBeGreaterThan(0);
+      for (const device of json) {
+        if (!isDeviceWithReportsResponse(device)) {
+          expect.fail("unexpected response shape");
+        }
+        expect(device.reports.length).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it("should return 400 for an invalid limit", async () => {
+      const zero = await devices.request(
+        "/reports?limit=0",
+        { method: "GET" },
+        env,
+      );
+      expect(zero.status).toBe(400);
+
+      const nan = await devices.request(
+        "/reports?limit=abc",
+        { method: "GET" },
+        env,
+      );
+      expect(nan.status).toBe(400);
     });
   });
 

--- a/worker/src/app/api/devices.ts
+++ b/worker/src/app/api/devices.ts
@@ -12,18 +12,29 @@ const devices = honoFactory
     const allDevices = await db.query.devices.findMany();
     return c.json(allDevices);
   })
-  .get("/reports", async (c) => {
-    const db = c.get("db");
-    const reportsList = await db.query.devices.findMany({
-      with: {
-        reports: {
-          orderBy: [desc(schema.reports.createdAt)],
+  .get(
+    "/reports",
+    zValidator(
+      "query",
+      z.object({
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+      }),
+    ),
+    async (c) => {
+      const { limit } = c.req.valid("query");
+      const db = c.get("db");
+      const reportsList = await db.query.devices.findMany({
+        with: {
+          reports: {
+            orderBy: [desc(schema.reports.createdAt)],
+            limit,
+          },
         },
-      },
-    });
+      });
 
-    return c.json(reportsList);
-  })
+      return c.json(reportsList);
+    },
+  )
   .post(
     "/",
     zValidator(

--- a/worker/src/app/devices/index.tsx
+++ b/worker/src/app/devices/index.tsx
@@ -1,0 +1,39 @@
+import { getDeviceByName } from "../../services/devices";
+import honoFactory from "../../services/honoFactory";
+
+function NotFound({ name }: { name: string }) {
+  return (
+    <div class="space-y-4">
+      <h2 class="text-xl font-semibold sm:text-2xl">
+        デバイスが見つかりません
+      </h2>
+      <p class="text-base-content/70 wrap-break-word">
+        「{name}」は登録されていません。
+      </p>
+      <a href="/" class="btn btn-primary btn-sm">
+        ダッシュボードへ戻る
+      </a>
+    </div>
+  );
+}
+
+const app = honoFactory.createApp().get("/:device", async (c) => {
+  // hono がパスパラメータをデコード済みで返す
+  const deviceName = c.req.param("device");
+  const db = c.get("db");
+
+  const device = await getDeviceByName(db, deviceName);
+  if (!device) {
+    c.status(404);
+    return c.render(<NotFound name={deviceName} />, {
+      title: "デバイスが見つかりません",
+    });
+  }
+
+  // 存在するデバイス名を data 属性で渡し、クライアント側でのパス解析を不要にする
+  return c.render(<div id="root" data-device={device.name} />, {
+    title: device.name,
+  });
+});
+
+export default app;

--- a/worker/src/app/index.test.ts
+++ b/worker/src/app/index.test.ts
@@ -1,5 +1,8 @@
 import { env } from "cloudflare:test";
+import { drizzle } from "drizzle-orm/d1";
 import { describe, it, expect } from "vitest";
+
+import * as schema from "../db/schema";
 import app from "./";
 
 describe("GET /", () => {
@@ -9,6 +12,48 @@ describe("GET /", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     expect(html).toContain('<div id="root"');
+  });
+
+  it("should render a mobile-ready document head", async () => {
+    const res = await app.request("/", {}, env);
+    const html = await res.text();
+    // viewport が欠けるとモバイルレイアウトが丸ごと無効になるため恒久的に検証する
+    expect(html).toContain('name="viewport"');
+    expect(html).toContain('lang="ja"');
+    expect(html).toContain("<title>");
+  });
+});
+
+describe("GET /devices/:device", () => {
+  it("should render the shell for a URL-encoded device name", async () => {
+    const db = drizzle(env.DB, { schema });
+    const name = `Detail Page Device ${String(Date.now())}`;
+    await db.insert(schema.devices).values({ name });
+
+    const res = await app.request(
+      `/devices/${encodeURIComponent(name)}`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const html = await res.text();
+    expect(html).toContain('<div id="root"');
+    // デコード済みのデバイス名がクライアントへ渡ること
+    expect(html).toContain(`data-device="${name}"`);
+    expect(html).toContain(`<title>${name} | Heartbeat Monitor</title>`);
+  });
+
+  it("should return 404 for an unknown device", async () => {
+    const res = await app.request("/devices/NoSuchDevice", {}, env);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const html = await res.text();
+    // クライアントJSを起動させない
+    expect(html).not.toContain('<div id="root"');
+    expect(html).toContain("デバイスが見つかりません");
   });
 });
 

--- a/worker/src/app/index.ts
+++ b/worker/src/app/index.ts
@@ -1,12 +1,14 @@
 import honoFactory from "../services/honoFactory";
 import api from "./api";
 import dashboard from "./dashboard";
+import devicePage from "./devices";
 import { renderer } from "./renderer";
 
 const app = honoFactory
   .createApp()
   .use(renderer)
   .route("/api", api)
+  .route("/devices", devicePage)
   .route("/", dashboard)
   .get("/dashboard", (c) => {
     return c.redirect("/");

--- a/worker/src/app/renderer.tsx
+++ b/worker/src/app/renderer.tsx
@@ -1,10 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+/* eslint-disable @typescript-eslint/prefer-function-type -- 宣言マージには interface が必要で、type エイリアスにするとマージされない */
 import { jsxRenderer } from "hono/jsx-renderer";
 
-export const renderer = jsxRenderer(({ children }) => {
+// c.render(node, { title }) を型安全に使えるようにする宣言マージ
+declare module "hono" {
+  interface ContextRenderer {
+    (content: string | Promise<string>, props?: { title?: string }): Response;
+  }
+}
+
+const SITE_TITLE = "Heartbeat Monitor";
+
+export const renderer = jsxRenderer(({ children, title }) => {
   return (
-    <html>
+    <html lang="ja" data-theme="light">
       <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title ? `${title} | ${SITE_TITLE}` : SITE_TITLE}</title>
         <link
           href={import.meta.env?.DEV ? `/src/style.css` : `/assets/style.css`}
           rel="stylesheet"
@@ -15,7 +28,18 @@ export const renderer = jsxRenderer(({ children }) => {
           <script type="module" src="/static/client.js"></script>
         )}
       </head>
-      <body>{children}</body>
+      <body class="min-h-dvh bg-base-200 text-base-content">
+        <header class="sticky top-0 z-10 bg-base-100 shadow-sm">
+          <div class="mx-auto w-full max-w-5xl px-2">
+            <a href="/" class="btn btn-ghost px-2 text-lg font-bold">
+              {SITE_TITLE}
+            </a>
+          </div>
+        </header>
+        <main class="mx-auto w-full max-w-5xl px-4 py-6 sm:py-8">
+          {children}
+        </main>
+      </body>
     </html>
   );
 });

--- a/worker/src/client/Dashboard/index.tsx
+++ b/worker/src/client/Dashboard/index.tsx
@@ -1,119 +1,73 @@
-import type { InferResponseType } from "hono/client";
-import { hc } from "hono/client";
-import { Suspense, use } from "hono/jsx/dom";
-import type { AppType } from "../../app";
+import { ErrorBoundary, Suspense, use } from "hono/jsx/dom";
 
-const client = hc<AppType>("/");
+import type { DeviceStatus, DeviceWithReports } from "../api";
+import { client } from "../api";
+import DeviceStatusCard from "../components/DeviceStatusCard";
+import ErrorState from "../components/ErrorState";
+import ReportList from "../components/ReportList";
+import { deviceHref } from "../utils";
 
-async function fetchStatus() {
+const REPORTS_PREVIEW_LIMIT = 5;
+
+async function fetchStatus(): Promise<DeviceStatus[]> {
   const res = await client.api.status.$get();
   return res.json();
 }
 
-function getStatusClass(status: string): string {
-  switch (status) {
-    case "ok":
-      return "bg-green-100 hover:bg-green-200";
-    case "error":
-      return "bg-red-100 hover:bg-red-200";
-    case "warn":
-      return "bg-yellow-100 hover:bg-yellow-200";
-    default:
-      return "bg-gray-50 hover:bg-gray-100";
-  }
+async function fetchReports(): Promise<DeviceWithReports[]> {
+  const res = await client.api.devices.reports.$get({
+    query: { limit: String(REPORTS_PREVIEW_LIMIT) },
+  });
+  return res.json();
 }
 
-function Status({
-  statusPromise,
-}: {
-  statusPromise: Promise<InferResponseType<typeof client.api.status.$get>>;
-}) {
-  const status = use(statusPromise);
+function Loading() {
+  return <p class="text-base-content/60">Loading...</p>;
+}
+
+function Status({ statusPromise }: { statusPromise: Promise<DeviceStatus[]> }) {
+  const statuses = use(statusPromise);
+
+  if (statuses.length === 0) {
+    return <p class="text-base-content/60">デバイスが登録されていません</p>;
+  }
+
   return (
-    <div class="overflow-x-auto rounded-lg border border-gray-200 shadow-sm">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-              機器名
-            </th>
-            <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-              ステータス
-            </th>
-            <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-              最終ログ日時
-            </th>
-            <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-              最終ログからの経過時間（秒）
-            </th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-200 bg-white">
-          {status.map((s) => (
-            <tr key={s.device} class={getStatusClass(s.status)}>
-              <td class="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
-                {s.device}
-              </td>
-              <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                {s.status}
-              </td>
-              <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                {new Date(s.lastLogAt).toLocaleString()}
-              </td>
-              <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                {s.timeSinceLastLogSeconds ?? "N/A"}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {statuses.map((status) => (
+        <DeviceStatusCard key={status.device} status={status} />
+      ))}
     </div>
   );
-}
-
-async function fetchReports() {
-  const res = await client.api.devices.reports.$get();
-  return res.json();
 }
 
 function Reports({
   deviceReportsPromise,
 }: {
-  deviceReportsPromise: Promise<
-    InferResponseType<typeof client.api.devices.reports.$get>
-  >;
+  deviceReportsPromise: Promise<DeviceWithReports[]>;
 }) {
   const devices = use(deviceReportsPromise);
+
+  if (devices.length === 0) {
+    return <p class="text-base-content/60">デバイスが登録されていません</p>;
+  }
+
   return (
-    <div class="space-y-6">
+    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
       {devices.map(({ name, reports }) => (
-        <div key={name}>
-          <h3 class="mb-3 text-xl font-semibold text-gray-800">{name}</h3>
-          <div class="overflow-x-auto rounded-lg border border-gray-200 shadow-sm">
-            <table class="min-w-full divide-y divide-gray-200">
-              <thead class="bg-gray-50">
-                <tr>
-                  <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-                    日時
-                  </th>
-                  <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-700">
-                    ステータス
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-200 bg-white">
-                {reports.map((report) => (
-                  <tr key={report.id} class={getStatusClass(report.status)}>
-                    <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                      {new Date(report.createdAt).toLocaleString()}
-                    </td>
-                    <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900">
-                      {report.status}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        <div
+          key={name}
+          class="card border border-base-300 bg-base-100 shadow-sm"
+        >
+          <div class="card-body gap-2 p-4">
+            <h3 class="font-semibold wrap-break-word">{name}</h3>
+            <ReportList reports={reports} />
+            <a
+              href={deviceHref(name)}
+              class="link link-primary self-end text-sm"
+            >
+              すべて見る →
+            </a>
           </div>
         </div>
       ))}
@@ -123,21 +77,23 @@ function Reports({
 
 function Dashboard() {
   return (
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="mb-8 text-4xl font-bold text-gray-900">Heartbeat Monitor</h1>
-
-      <section class="mb-12">
-        <h2 class="mb-4 text-2xl font-semibold text-gray-800">Status</h2>
-        <Suspense fallback={<p class="text-gray-500">Loading...</p>}>
-          <Status statusPromise={fetchStatus()} />
-        </Suspense>
+    <div class="space-y-10">
+      <section class="space-y-4">
+        <h2 class="text-xl font-semibold sm:text-2xl">Status</h2>
+        <ErrorBoundary fallback={<ErrorState />}>
+          <Suspense fallback={<Loading />}>
+            <Status statusPromise={fetchStatus()} />
+          </Suspense>
+        </ErrorBoundary>
       </section>
 
-      <section>
-        <h2 class="mb-4 text-2xl font-semibold text-gray-800">Reports</h2>
-        <Suspense fallback={<p class="text-gray-500">Loading...</p>}>
-          <Reports deviceReportsPromise={fetchReports()} />
-        </Suspense>
+      <section class="space-y-4">
+        <h2 class="text-xl font-semibold sm:text-2xl">Reports</h2>
+        <ErrorBoundary fallback={<ErrorState />}>
+          <Suspense fallback={<Loading />}>
+            <Reports deviceReportsPromise={fetchReports()} />
+          </Suspense>
+        </ErrorBoundary>
       </section>
     </div>
   );

--- a/worker/src/client/Dashboard/index.tsx
+++ b/worker/src/client/Dashboard/index.tsx
@@ -4,6 +4,7 @@ import type { DeviceStatus, DeviceWithReports } from "../api";
 import { client } from "../api";
 import DeviceStatusCard from "../components/DeviceStatusCard";
 import ErrorState from "../components/ErrorState";
+import Loading from "../components/Loading";
 import ReportList from "../components/ReportList";
 import { deviceHref } from "../utils";
 
@@ -19,10 +20,6 @@ async function fetchReports(): Promise<DeviceWithReports[]> {
     query: { limit: String(REPORTS_PREVIEW_LIMIT) },
   });
   return res.json();
-}
-
-function Loading() {
-  return <p class="text-base-content/60">Loading...</p>;
 }
 
 function Status({ statusPromise }: { statusPromise: Promise<DeviceStatus[]> }) {

--- a/worker/src/client/DeviceDetail/index.tsx
+++ b/worker/src/client/DeviceDetail/index.tsx
@@ -1,10 +1,12 @@
 import { ErrorBoundary, Suspense, use } from "hono/jsx/dom";
 
 import { client } from "../api";
+import ElapsedTime from "../components/ElapsedTime";
 import ErrorState from "../components/ErrorState";
+import Loading from "../components/Loading";
 import ReportList from "../components/ReportList";
 import StatusBadge from "../components/StatusBadge";
-import { encodeDeviceName, formatDateTime, formatElapsed } from "../utils";
+import { encodeDeviceName, formatDateTime } from "../utils";
 
 async function fetchDeviceDetail(deviceName: string) {
   // hono の RPC クライアントはパスパラメータをエンコードしないので自前で行う
@@ -54,7 +56,7 @@ function Detail({
         <div class="stat">
           <div class="stat-title">経過時間</div>
           <div class="stat-value text-lg sm:text-2xl">
-            {formatElapsed(status.timeSinceLastLogSeconds)}
+            <ElapsedTime seconds={status.timeSinceLastLogSeconds} />
           </div>
         </div>
       </div>
@@ -84,7 +86,7 @@ function DeviceDetail({ deviceName }: { deviceName: string }) {
       </div>
 
       <ErrorBoundary fallback={<ErrorState />}>
-        <Suspense fallback={<p class="text-base-content/60">Loading...</p>}>
+        <Suspense fallback={<Loading />}>
           <Detail detailPromise={fetchDeviceDetail(deviceName)} />
         </Suspense>
       </ErrorBoundary>

--- a/worker/src/client/DeviceDetail/index.tsx
+++ b/worker/src/client/DeviceDetail/index.tsx
@@ -1,0 +1,95 @@
+import { ErrorBoundary, Suspense, use } from "hono/jsx/dom";
+
+import { client } from "../api";
+import ErrorState from "../components/ErrorState";
+import ReportList from "../components/ReportList";
+import StatusBadge from "../components/StatusBadge";
+import { encodeDeviceName, formatDateTime, formatElapsed } from "../utils";
+
+async function fetchDeviceDetail(deviceName: string) {
+  // hono の RPC クライアントはパスパラメータをエンコードしないので自前で行う
+  const param = { device: encodeDeviceName(deviceName) };
+
+  const [statusRes, reportsRes] = await Promise.all([
+    client.api.status[":device"].$get({ param }),
+    client.api.reports[":device"].$get({ param }),
+  ]);
+
+  // 存在確認はサーバールートで済んでいるので、ここでの失敗は通信障害か直前の削除
+  if (!statusRes.ok || !reportsRes.ok) {
+    throw new Error("Failed to fetch device detail");
+  }
+
+  const [status, reports] = await Promise.all([
+    statusRes.json(),
+    reportsRes.json(),
+  ]);
+
+  return { status, reports };
+}
+
+function Detail({
+  detailPromise,
+}: {
+  detailPromise: ReturnType<typeof fetchDeviceDetail>;
+}) {
+  const { status, reports } = use(detailPromise);
+
+  return (
+    <div class="space-y-6">
+      <div class="flex flex-wrap items-center gap-3">
+        <h2 class="text-xl font-semibold wrap-break-word sm:text-2xl">
+          {status.device}
+        </h2>
+        <StatusBadge status={status.status} />
+      </div>
+
+      <div class="stats stats-vertical w-full border border-base-300 bg-base-100 shadow-sm sm:stats-horizontal">
+        <div class="stat">
+          <div class="stat-title">最終ログ</div>
+          <div class="stat-value text-lg sm:text-2xl">
+            {formatDateTime(status.lastLogAt)}
+          </div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">経過時間</div>
+          <div class="stat-value text-lg sm:text-2xl">
+            {formatElapsed(status.timeSinceLastLogSeconds)}
+          </div>
+        </div>
+      </div>
+
+      <section class="space-y-3">
+        <h3 class="text-lg font-semibold">ステータス履歴</h3>
+        <div class="card border border-base-300 bg-base-100 shadow-sm">
+          <div class="card-body p-4">
+            <ReportList reports={reports} />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function DeviceDetail({ deviceName }: { deviceName: string }) {
+  return (
+    <div class="space-y-4">
+      <div class="breadcrumbs text-sm">
+        <ul>
+          <li>
+            <a href="/">ダッシュボード</a>
+          </li>
+          <li>{deviceName}</li>
+        </ul>
+      </div>
+
+      <ErrorBoundary fallback={<ErrorState />}>
+        <Suspense fallback={<p class="text-base-content/60">Loading...</p>}>
+          <Detail detailPromise={fetchDeviceDetail(deviceName)} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+export default DeviceDetail;

--- a/worker/src/client/api.ts
+++ b/worker/src/client/api.ts
@@ -1,0 +1,17 @@
+import type { InferResponseType } from "hono/client";
+import { hc } from "hono/client";
+
+import type { AppType } from "../app";
+
+export const client = hc<AppType>("/");
+
+// `, 200` を明示しないと :device 系のレスポンス型に 404/500 の { error } が混ざる
+export type DeviceStatus = InferResponseType<
+  typeof client.api.status.$get,
+  200
+>[number];
+
+export type DeviceWithReports = InferResponseType<
+  typeof client.api.devices.reports.$get,
+  200
+>[number];

--- a/worker/src/client/components/DeviceStatusCard.tsx
+++ b/worker/src/client/components/DeviceStatusCard.tsx
@@ -1,5 +1,6 @@
 import type { DeviceStatus } from "../api";
-import { deviceHref, formatDateTime, formatElapsed } from "../utils";
+import { deviceHref, formatDateTime } from "../utils";
+import ElapsedTime from "./ElapsedTime";
 import StatusBadge, { statusAccentClass } from "./StatusBadge";
 
 function DeviceStatusCard({ status }: { status: DeviceStatus }) {
@@ -18,7 +19,7 @@ function DeviceStatusCard({ status }: { status: DeviceStatus }) {
           <dd class="text-right">{formatDateTime(status.lastLogAt)}</dd>
           <dt class="text-base-content/60">経過</dt>
           <dd class="text-right">
-            {formatElapsed(status.timeSinceLastLogSeconds)}
+            <ElapsedTime seconds={status.timeSinceLastLogSeconds} />
           </dd>
         </dl>
       </div>

--- a/worker/src/client/components/DeviceStatusCard.tsx
+++ b/worker/src/client/components/DeviceStatusCard.tsx
@@ -1,0 +1,29 @@
+import type { DeviceStatus } from "../api";
+import { deviceHref, formatDateTime, formatElapsed } from "../utils";
+import StatusBadge, { statusAccentClass } from "./StatusBadge";
+
+function DeviceStatusCard({ status }: { status: DeviceStatus }) {
+  return (
+    <a
+      href={deviceHref(status.device)}
+      class={`card border border-base-300 border-l-4 bg-base-100 shadow-sm transition hover:shadow-md ${statusAccentClass(status.status)}`}
+    >
+      <div class="card-body gap-3 p-4">
+        <div class="flex items-start justify-between gap-2">
+          <h3 class="font-semibold wrap-break-word">{status.device}</h3>
+          <StatusBadge status={status.status} />
+        </div>
+        <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+          <dt class="text-base-content/60">最終ログ</dt>
+          <dd class="text-right">{formatDateTime(status.lastLogAt)}</dd>
+          <dt class="text-base-content/60">経過</dt>
+          <dd class="text-right">
+            {formatElapsed(status.timeSinceLastLogSeconds)}
+          </dd>
+        </dl>
+      </div>
+    </a>
+  );
+}
+
+export default DeviceStatusCard;

--- a/worker/src/client/components/ElapsedTime.tsx
+++ b/worker/src/client/components/ElapsedTime.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "hono/jsx/dom";
+
+import { formatElapsed } from "../utils";
+
+/**
+ * 経過時間を1秒ごとに更新して表示する。
+ *
+ * サーバーが算出した秒数を基点に、マウントからの実時間を足して求める。
+ * lastLogAt から端末の時計で直接計算すると時計ずれがそのまま表示に出るため、
+ * サーバー基準の値からの差分だけをクライアントで進める。
+ *
+ * useState は Object.is で差分を判定するので、表示文字列が変わらない限り
+ * 再描画は発生しない（「200日前」のような値では実質何も起きない）。
+ */
+function ElapsedTime({ seconds }: { seconds: number | undefined }) {
+  const [label, setLabel] = useState(() => formatElapsed(seconds));
+
+  useEffect(() => {
+    if (seconds === undefined) {
+      return;
+    }
+
+    const baseSeconds = seconds;
+    const mountedAt = Date.now();
+
+    const timer = setInterval(() => {
+      // 毎回実時間から求め直すため、スリープ復帰後もずれない
+      const elapsed = baseSeconds + Math.floor((Date.now() - mountedAt) / 1000);
+      setLabel(formatElapsed(elapsed));
+    }, 1000);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [seconds]);
+
+  return <span>{label}</span>;
+}
+
+export default ElapsedTime;

--- a/worker/src/client/components/ErrorState.tsx
+++ b/worker/src/client/components/ErrorState.tsx
@@ -1,0 +1,18 @@
+function ErrorState({ message = "データの取得に失敗しました" }) {
+  return (
+    <div role="alert" class="alert alert-error">
+      <span>{message}</span>
+      <button
+        type="button"
+        class="btn btn-sm"
+        onClick={() => {
+          location.reload();
+        }}
+      >
+        再読み込み
+      </button>
+    </div>
+  );
+}
+
+export default ErrorState;

--- a/worker/src/client/components/Loading.tsx
+++ b/worker/src/client/components/Loading.tsx
@@ -1,0 +1,9 @@
+function Loading() {
+  return (
+    <div class="flex justify-center py-8" role="status" aria-label="読み込み中">
+      <span class="loading loading-spinner loading-lg text-base-content/30" />
+    </div>
+  );
+}
+
+export default Loading;

--- a/worker/src/client/components/ReportList.tsx
+++ b/worker/src/client/components/ReportList.tsx
@@ -1,0 +1,39 @@
+import type { status } from "../../types";
+import { formatDateTime } from "../utils";
+import StatusBadge from "./StatusBadge";
+
+/**
+ * /api/devices/reports と /api/reports/:device のどちらの行も
+ * 構造的にこれを満たすので、トップと詳細で同じコンポーネントを使える。
+ */
+export interface ReportItem {
+  id: number;
+  status: status;
+  createdAt: string;
+}
+
+function ReportList({ reports }: { reports: ReportItem[] }) {
+  if (reports.length === 0) {
+    return (
+      <p class="py-2 text-sm text-base-content/60">まだ記録がありません</p>
+    );
+  }
+
+  return (
+    <ul class="divide-y divide-base-300">
+      {reports.map((report) => (
+        <li
+          key={report.id}
+          class="flex items-center justify-between gap-3 py-2"
+        >
+          <span class="text-sm text-base-content/80">
+            {formatDateTime(report.createdAt)}
+          </span>
+          <StatusBadge status={report.status} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default ReportList;

--- a/worker/src/client/components/StatusBadge.tsx
+++ b/worker/src/client/components/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import type { status } from "../../types";
+
+/**
+ * Tailwind v4 はソース中のリテラルしかクラス名として検出しないため、
+ * `badge-${status}` のような組み立ては禁止。ここが唯一のマップ。
+ * 色は services/discord.ts の STATUS_COLORS と揃えている。
+ */
+const STATUS_STYLES: Record<status, { badge: string; accent: string }> = {
+  ok: { badge: "badge-success", accent: "border-l-success" },
+  warn: { badge: "badge-warning", accent: "border-l-warning" },
+  error: { badge: "badge-error", accent: "border-l-error" },
+  pending: { badge: "badge-neutral", accent: "border-l-neutral" },
+};
+
+export function statusAccentClass(value: status): string {
+  return STATUS_STYLES[value].accent;
+}
+
+function StatusBadge({ status: value }: { status: status }) {
+  return (
+    <span class={`badge badge-sm ${STATUS_STYLES[value].badge}`}>{value}</span>
+  );
+}
+
+export default StatusBadge;

--- a/worker/src/client/index.tsx
+++ b/worker/src/client/index.tsx
@@ -1,11 +1,18 @@
 import { render } from "hono/jsx/dom";
-import Dashboard from "./Dashboard";
 
-function App() {
-  return <Dashboard />;
-}
+import Dashboard from "./Dashboard";
+import DeviceDetail from "./DeviceDetail";
 
 const root = document.getElementById("root");
 if (root) {
-  render(<App />, root);
+  // サーバー側がデコード済みのデバイス名を data 属性で渡す（詳細ページのみ）
+  const deviceName = root.dataset.device;
+  render(
+    deviceName === undefined ? (
+      <Dashboard />
+    ) : (
+      <DeviceDetail deviceName={deviceName} />
+    ),
+    root,
+  );
 }

--- a/worker/src/client/utils.ts
+++ b/worker/src/client/utils.ts
@@ -1,0 +1,58 @@
+const dateTimeFormat = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+/**
+ * 日時文字列を表示用に整形する。
+ * pending なデバイスは lastLogAt が空文字なので "—" を返す。
+ */
+export function formatDateTime(value: string | undefined): string {
+  if (!value) {
+    return "—";
+  }
+  // 旧マイグレーションの CURRENT_TIMESTAMP は "YYYY-MM-DD HH:MM:SS" 形式
+  const normalized = value.includes("T")
+    ? value
+    : `${value.replace(" ", "T")}Z`;
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+  return dateTimeFormat.format(date);
+}
+
+/** 経過秒数を「◯分前」のような相対表現にする。 */
+export function formatElapsed(seconds: number | undefined): string {
+  if (seconds === undefined) {
+    return "—";
+  }
+  if (seconds < 60) {
+    return `${String(seconds)}秒前`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${String(minutes)}分前`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${String(hours)}時間前`;
+  }
+  return `${String(Math.floor(hours / 24))}日前`;
+}
+
+/**
+ * デバイス名をURLセグメントとして安全な形にする。
+ * hono の RPC クライアントはパスパラメータをエンコードせずに埋め込むため、
+ * リンク生成でも API 呼び出しでも必ずこれを通すこと。
+ */
+export function encodeDeviceName(name: string): string {
+  return encodeURIComponent(name);
+}
+
+export function deviceHref(name: string): string {
+  return `/devices/${encodeDeviceName(name)}`;
+}

--- a/worker/src/style.css
+++ b/worker/src/style.css
@@ -1,1 +1,4 @@
 @import "tailwindcss";
+@plugin "daisyui" {
+  themes: light --default;
+}


### PR DESCRIPTION
モバイル画面でダッシュボードが見づらい問題と、Reports セクションが無制限に伸びていく問題に対応します。

## レイアウトの再構成

- **`renderer.tsx` に viewport meta を追加**（`charset` / `<title>` / `lang="ja"` も併せて）。これが無かったためモバイルブラウザは 980px の仮想ビューポートでレンダリングし、ページ全体が縮小表示されていました。単体で最も効果の大きい変更です
- UI に **daisyUI v5** を導入（Tailwind の CSS プラグインなので hono/jsx でもそのまま使えます）。テーマは light のみ
- 横スクロールしていた2つの `<table>` をカードレイアウトへ置き換え。フィールドが4つしかないためデスクトップでもテーブルの利点がなく、全ブレークポイントでカードに統一しています
- ヘッダとコンテナをサーバーサイドの共通シェルへ移動。`#root` は SSR 時点で空なので、これで JS ロード前でもヘッダが描画されます
- 共通コンポーネントを `src/client/components/` に切り出し（`StatusBadge` / `DeviceStatusCard` / `ReportList` / `ErrorState`）

## Reports の分割

- `GET /api/devices/reports` に `?limit` を追加。drizzle の `with: { reports: { limit } }` は相関サブクエリになるため**デバイスごと**に適用されます
- トップページは最新5件のみ表示し、「すべて見る →」で詳細ページへ
- **`GET /devices/:device` を追加**。ステータス概要（最終ログ / 経過時間）とレポート全件を表示します
  - サーバー側で `getDeviceByName` により存在確認し、未登録なら **404**（クライアント JS は起動しません）
  - デコード済みのデバイス名を `data-device` 属性でクライアントへ渡すため、`location.pathname` の再パースは不要です

レポートは1分間隔の cron がステータス遷移のたびに書き込むため、`/api/devices/reports` のレスポンスは単調増加していました。クライアント側の `slice` ではなくサーバー側で絞ることで、転送量と D1 の読み取りの両方を削減しています。

## ついでの修正

- `pending` デバイスは `lastLogAt` が空文字のため `Invalid Date` と表示されていたのを `—` に
- 経過秒数の生値（`847`）を「14分前」形式へ
- fetch 失敗時にスピナーが回り続けないよう `ErrorBoundary` を追加（従来エラー処理が皆無でした）
- prettier が drizzle 管理下の `migrations/` を整形してしまうため `.prettierignore` を追加

## テスト

- `GET /reports` の limit テスト4件を追加。うち1件は「limit がグローバルではなくデバイスごとに効く」ことを固定するものです
- ルートアプリのテストに viewport meta の検証と `/devices/:device` の 200 / 404 を追加。viewport の回帰はこの改修全体を静かに無効化するため恒久的に残しています

## 動作確認

- `npm run lint` / `format` / `tsc` / `test`（31 tests）すべて通過
- `npm run dev` にて 375×667 と 1280×900 で確認。横スクロールなし、コンソールエラーなし
- `npm run preview`（本番ビルド）で `/assets/style.css`・`/static/client.js` の解決と `/devices/...` のフォールスルーを確認
- `/` を含むデバイス名（`SWEET WORK / Arduino UNO R4 WiFi`）でも詳細ページが正しく開くことを確認。hono の RPC クライアントはパスパラメータをエンコードしないため、`encodeDeviceName()` を必ず通しています

<details>
<summary>スクリーンショット（375×667）</summary>

Status はカードのグリッド、Reports はデバイスごとに最新5件＋「すべて見る →」。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard with responsive device status cards and recent report previews.
  * Added device detail pages with status information, report history, navigation, and loading/error states.
  * Added light-theme styling and responsive page layouts.
  * Added report filtering with configurable per-device limits from 1 to 100.
  * Added clear not-found pages for unavailable devices.

* **Bug Fixes**
  * Improved report limit validation and ensured limits apply independently to each device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->