### PR TITLE
feat: ステータスの定期再取得を追加

### DIFF
--- a/worker/src/client/Dashboard/index.tsx
+++ b/worker/src/client/Dashboard/index.tsx
@@ -6,6 +6,7 @@ import DeviceStatusCard from "../components/DeviceStatusCard";
 import ErrorState from "../components/ErrorState";
 import Loading from "../components/Loading";
 import ReportList from "../components/ReportList";
+import { usePolling } from "../polling";
 import { deviceHref } from "../utils";
 
 const REPORTS_PREVIEW_LIMIT = 5;
@@ -23,7 +24,7 @@ async function fetchReports(): Promise<DeviceWithReports[]> {
 }
 
 function Status({ statusPromise }: { statusPromise: Promise<DeviceStatus[]> }) {
-  const statuses = use(statusPromise);
+  const statuses = usePolling(use(statusPromise), fetchStatus);
 
   if (statuses.length === 0) {
     return <p class="text-base-content/60">デバイスが登録されていません</p>;
@@ -43,7 +44,7 @@ function Reports({
 }: {
   deviceReportsPromise: Promise<DeviceWithReports[]>;
 }) {
-  const devices = use(deviceReportsPromise);
+  const devices = usePolling(use(deviceReportsPromise), fetchReports);
 
   if (devices.length === 0) {
     return <p class="text-base-content/60">デバイスが登録されていません</p>;

--- a/worker/src/client/DeviceDetail/index.tsx
+++ b/worker/src/client/DeviceDetail/index.tsx
@@ -6,6 +6,7 @@ import ErrorState from "../components/ErrorState";
 import Loading from "../components/Loading";
 import ReportList from "../components/ReportList";
 import StatusBadge from "../components/StatusBadge";
+import { usePolling } from "../polling";
 import { encodeDeviceName, formatDateTime } from "../utils";
 
 async function fetchDeviceDetail(deviceName: string) {
@@ -31,11 +32,15 @@ async function fetchDeviceDetail(deviceName: string) {
 }
 
 function Detail({
+  deviceName,
   detailPromise,
 }: {
+  deviceName: string;
   detailPromise: ReturnType<typeof fetchDeviceDetail>;
 }) {
-  const { status, reports } = use(detailPromise);
+  const { status, reports } = usePolling(use(detailPromise), () =>
+    fetchDeviceDetail(deviceName),
+  );
 
   return (
     <div class="space-y-6">
@@ -87,7 +92,10 @@ function DeviceDetail({ deviceName }: { deviceName: string }) {
 
       <ErrorBoundary fallback={<ErrorState />}>
         <Suspense fallback={<Loading />}>
-          <Detail detailPromise={fetchDeviceDetail(deviceName)} />
+          <Detail
+            deviceName={deviceName}
+            detailPromise={fetchDeviceDetail(deviceName)}
+          />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/worker/src/client/polling.ts
+++ b/worker/src/client/polling.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "hono/jsx/dom";
+
+/**
+ * 再取得の間隔。
+ * サーバー側の cron が1分間隔でステータスを評価するため、
+ * それより短くしても新しい情報は増えないが、閾値（warn 2分 / error 5分）を
+ * またいだことに気づくまでの遅れを抑えるため 30 秒にしている。
+ */
+export const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * 初回に取得済みのデータを起点に、一定間隔で再取得して最新化する。
+ *
+ * 初回ロードは呼び出し側の `use()` + `<Suspense>` が担当し、
+ * このフックは2回目以降だけを受け持つ。
+ *
+ * - タブが非表示の間は取得しない。表示に戻った時点で即座に最新化する
+ * - 再取得の失敗は握りつぶし、直前に取得できた値を表示し続ける
+ *   （一時的な通信断で画面が壊れるのを避けるため）
+ */
+export function usePolling<T>(
+  initialData: T,
+  fetcher: () => Promise<T>,
+  intervalMs: number = POLL_INTERVAL_MS,
+): T {
+  const [data, setData] = useState(initialData);
+
+  // fetcher は描画のたびに作り直される場合があるため、
+  // effect の依存に入れずに ref 経由で最新のものを参照する
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refetch = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      const currentFetcher = fetcherRef.current;
+      if (!currentFetcher) {
+        return;
+      }
+      currentFetcher()
+        .then((next) => {
+          if (!cancelled) {
+            setData(next);
+          }
+        })
+        .catch(() => {
+          // 直前の値を保持したまま次の間隔を待つ
+        });
+    };
+
+    const timer = setInterval(refetch, intervalMs);
+    document.addEventListener("visibilitychange", refetch);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", refetch);
+    };
+  }, [intervalMs]);
+
+  return data;
+}


### PR DESCRIPTION
> [!NOTE]
> #9 の上に積んだ stacked PR です。base は `feat/responsive-ui-and-device-detail`。#9 がマージされると GitHub が自動的に base を `main` に付け替えます。

## 背景

#9 で経過時間を毎秒更新するようにしましたが、**ステータスバッジ（ok/warn/error）はサーバー取得時のまま**でした。閾値は warn 2分 / error 5分で、判定は `worker/src/config.ts` を参照するサーバー側にあるため、画面を開いたまま放置すると「経過時間は 7分前 と表示されているのにバッジは ok のまま」という状態になります。

## 変更内容

`usePolling` フック（`worker/src/client/polling.ts`）を追加し、30秒間隔で再取得します。

```ts
const statuses = usePolling(use(statusPromise), fetchStatus);
```

**初回ロードは既存の `use()` + `<Suspense>` がそのまま担当**し、このフックは2回目以降だけを受け持ちます。ローディング表示やエラー境界の扱いは変わりません。

### 設計上の判断

- **間隔は30秒** — サーバー側の cron が1分間隔でステータスを評価するため、それより短くしても新しい情報は増えません。一方で閾値をまたいだことに気づくまでの遅れを抑えたいので、cron の半分にしています
- **タブが非表示の間は取得しない** — 表示に戻った時点で `visibilitychange` により即座に最新化します。バックグラウンドのタブが延々とリクエストを投げ続けるのを避けるためです
- **再取得の失敗は握りつぶす** — 直前に取得できた値を表示し続けます。一時的な通信断で画面が壊れる方が体験として悪いためです。裏を返すと**恒久的な障害が「少し古いデータ」として静かに見える**ことになります。表示が必要なら別途対応します
- `fetcher` は描画のたびに作り直される場合があるため、effect の依存には入れず ref 経由で最新のものを参照しています

## 動作確認

`npm run dev` 上で `window.fetch` を計測して検証しました。

| 確認項目 | 結果 |
| --- | --- |
| 初回ロード | `/api/status` と `/api/devices/reports?limit=5` の2件 |
| タブ非表示中の `visibilitychange` | 取得0件 |
| 表示復帰時の `visibilitychange` | 即座に2件 |
| 34秒待機 | 2件（30秒のティック1回ぶん） |

あわせて実データでも確認しています。待機中に `ESP32-Sensor-1` へハートビートを投入したところ、リロードなしでカードの表示が変化しました。

```
待機前: ESP32-Sensor-1 error 最終ログ 2026/01/12 23:53 経過 200日前
待機後: ESP32-Sensor-1 ok    最終ログ 2026/08/01 16:02 経過 39秒前
```

`npm run lint` / `tsc` / `test`（31 tests）すべて通過しています。

なお、クライアント側のテストは `@cloudflare/vitest-pool-workers`（workerd、DOM なし）の制約で追加していません（#9 と同じ理由）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)