### PR TITLE
fix: 日時表示のタイムゾーンを Asia/Tokyo に固定

### DIFF
--- a/worker/src/client/utils.test.ts
+++ b/worker/src/client/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { deviceHref, formatDateTime, formatElapsed } from "./utils";
+
+describe("formatDateTime", () => {
+  // Workers ランタイムは UTC で動くため、タイムゾーンを固定していなければ
+  // ここは "2026/01/02 15:30" になる。ブラウザ（JST）との不一致を検知する。
+  it("should format in JST regardless of the runtime time zone", () => {
+    expect(formatDateTime("2026-01-02T15:30:00Z")).toBe("2026/01/03 00:30");
+  });
+
+  it("should handle the legacy 'YYYY-MM-DD HH:MM:SS' form as UTC", () => {
+    expect(formatDateTime("2026-01-02 15:30:00")).toBe("2026/01/03 00:30");
+  });
+
+  it("should return a dash for empty input", () => {
+    // pending なデバイスは lastLogAt が空文字
+    expect(formatDateTime("")).toBe("—");
+    expect(formatDateTime(undefined)).toBe("—");
+  });
+
+  it("should return a dash for an unparsable value", () => {
+    expect(formatDateTime("nonsense")).toBe("—");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("should format seconds, minutes, hours and days", () => {
+    expect(formatElapsed(0)).toBe("0秒前");
+    expect(formatElapsed(59)).toBe("59秒前");
+    expect(formatElapsed(60)).toBe("1分前");
+    expect(formatElapsed(3599)).toBe("59分前");
+    expect(formatElapsed(3600)).toBe("1時間前");
+    expect(formatElapsed(86_399)).toBe("23時間前");
+    expect(formatElapsed(86_400)).toBe("1日前");
+  });
+
+  it("should return a dash when the elapsed time is unknown", () => {
+    expect(formatElapsed(undefined)).toBe("—");
+  });
+});
+
+describe("deviceHref", () => {
+  it("should percent-encode characters that would break the path", () => {
+    // hono の RPC クライアントもリンクもこの関数を通す前提
+    expect(deviceHref("SWEET WORK / Arduino")).toBe(
+      "/devices/SWEET%20WORK%20%2F%20Arduino",
+    );
+    expect(deviceHref('Quote "X" & <Y>')).toBe(
+      "/devices/Quote%20%22X%22%20%26%20%3CY%3E",
+    );
+  });
+});

--- a/worker/src/client/utils.ts
+++ b/worker/src/client/utils.ts
@@ -1,4 +1,9 @@
 const dateTimeFormat = new Intl.DateTimeFormat("ja-JP", {
+  // タイムゾーンを固定しないと、Workers ランタイム（UTC）とブラウザ（閲覧者の
+  // ローカル）で同じ日時が別の文字列になる。サーバーサイドレンダリングを入れると
+  // 差し替えの瞬間に全タイムスタンプが9時間飛ぶため、両者を一致させておく。
+  // lang="ja" / ja-JP と同様、監視対象が国内にある前提。
+  timeZone: "Asia/Tokyo",
   year: "numeric",
   month: "2-digit",
   day: "2-digit",

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -4,6 +4,11 @@ import {
 } from "@cloudflare/vitest-pool-workers/config";
 import path from "node:path";
 
+// 本番の Cloudflare Workers は UTC で動くが、ローカルの workerd は
+// ホストのタイムゾーンを継承してしまう。日時整形の検証が開発者の環境に
+// 依存しないよう、本番と同じ UTC に固定する。
+process.env.TZ = "UTC";
+
 export default defineWorkersProject(async () => {
   // Read all migrations in the `migrations` directory
   const migrationsPath = path.join(__dirname, "migrations");


### PR DESCRIPTION
> [!NOTE]
> サーバーサイドレンダリング対応の 1/3 本目です。後続: #(rename) → #(ssr)

## 問題

`Intl.DateTimeFormat` に `timeZone` 指定がなく、実行環境のローカル時刻で整形していました。本番の Cloudflare Workers は UTC で動くため、このままサーバーサイドレンダリングを入れると**同じ日時がサーバーとブラウザで9時間ずれ**、画面の引き継ぎ時に全タイムスタンプが飛びます。

## 変更

- `formatDateTime` の formatter に `timeZone: "Asia/Tokyo"` を指定
- `vitest.config.ts` で `TZ=UTC` を固定
- `utils.test.ts` を追加

## `TZ=UTC` を固定した理由

ローカルの workerd は**ホストのタイムゾーンを継承します**。実際に確認したところ `Intl.DateTimeFormat().resolvedOptions().timeZone` は `Asia/Tokyo` を返していました。そのため修正前のコードでもテストが通ってしまい、この回帰を検知できません。本番と同じ UTC に固定することで、テストが意味を持つようになります。

修正を戻して確認した結果:

```
× formatDateTime > should format in JST regardless of the runtime time zone
  → expected '2026/01/02 15:30' to be '2026/01/03 00:30'
```

## 検証

- `npm run lint` / `tsc` / `test`（38 tests）すべて通過
- ブラウザの ICU も同じ入力に対して `2026/01/03 00:30` を返すことを確認済み（workerd と一致）

## 影響

JST 圏外の閲覧者にも JST が表示されます。このアプリは `lang="ja"` / `ja-JP` をハードコードした国内向けの監視ダッシュボードなので、一貫性を優先しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 日時表示を日本時間（JST）に統一し、環境による表示のずれを防止しました。
  - 空欄や不正な日時にはダッシュを表示するなど、日時情報の表示を安定させました。
  - 経過時間や各種日時形式の表示を見直し、より一貫した結果を提供します。
  - URLに含まれる特殊文字を適切にエンコードし、リンクの動作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->