### PR TITLE
refactor: デバイス状態の取得を全件・単体で揃え、1クエリにまとめる

### DIFF
--- a/worker/src/app/api/status.test.ts
+++ b/worker/src/app/api/status.test.ts
@@ -30,6 +30,11 @@ function isStatusResponse(value: unknown): value is StatusResponse {
   );
 }
 
+// Array.isArray は unknown を any[] に絞ってしまうため、専用のガードを使う
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
 function isErrorResponse(value: unknown): value is ErrorResponse {
   return (
     !!value &&
@@ -138,6 +143,63 @@ describe("Status API", () => {
       expect(isErrorResponse(jsonUnknown)).toBe(true);
       if (!isErrorResponse(jsonUnknown)) return;
       expect(jsonUnknown.error).toBe("Device Not Found");
+    });
+  });
+
+  // 一覧・単体とも「デバイスごとに最新の1件」を取る実装なので、
+  // 複数ハートビートがある状態で最新が選ばれることを固定する。
+  describe("latest heartbeat selection", () => {
+    const newest = "2026-03-03T03:00:00Z";
+
+    async function seedDeviceWithThreeHeartbeats(): Promise<string> {
+      const db = drizzle(env.DB, { schema });
+      const name = `Multi Heartbeat Device ${String(Date.now())}`;
+      const [device] = await db
+        .insert(schema.devices)
+        .values({ name })
+        .returning();
+
+      // わざと新しい順で入れない（挿入順ではなく created_at で選ぶこと）
+      await db.insert(schema.heartbeats).values([
+        { deviceId: device.id, createdAt: "2026-01-01T01:00:00Z" },
+        { deviceId: device.id, createdAt: newest },
+        { deviceId: device.id, createdAt: "2026-02-02T02:00:00Z" },
+      ]);
+
+      return name;
+    }
+
+    it("should pick the newest heartbeat in the list endpoint", async () => {
+      const name = await seedDeviceWithThreeHeartbeats();
+
+      const res = await status.request("/", { method: "GET" }, env);
+      expect(res.status).toBe(200);
+
+      const json: unknown = await res.json();
+      if (!isUnknownArray(json)) {
+        expect.fail("expected an array");
+      }
+      const target = json.find((s) => isStatusResponse(s) && s.device === name);
+      if (!isStatusResponse(target)) {
+        expect.fail("seeded device not found in response");
+      }
+      expect(target.lastLogAt).toBe(newest);
+    });
+
+    it("should pick the newest heartbeat in the single endpoint", async () => {
+      const name = await seedDeviceWithThreeHeartbeats();
+
+      const res = await status.request(
+        `/${encodeURIComponent(name)}`,
+        { method: "GET" },
+        env,
+      );
+      expect(res.status).toBe(200);
+
+      const jsonUnknown = await res.json();
+      expect(isStatusResponse(jsonUnknown)).toBe(true);
+      if (!isStatusResponse(jsonUnknown)) return;
+      expect(jsonUnknown.lastLogAt).toBe(newest);
     });
   });
 });

--- a/worker/src/app/api/status.ts
+++ b/worker/src/app/api/status.ts
@@ -1,9 +1,4 @@
-import { getDeviceByName } from "../../services/devices";
-import {
-  enrichStatus,
-  getDeviceStatuses,
-  getHeartbeatStatus,
-} from "../../services/heartbeats";
+import { getDeviceStatus, getDeviceStatuses } from "../../services/heartbeats";
 import honoFactory from "../../services/honoFactory";
 
 const status = honoFactory
@@ -17,17 +12,12 @@ const status = honoFactory
     const deviceName = c.req.param("device");
     const db = c.get("db");
 
-    const device = await getDeviceByName(db, deviceName);
-    if (!device) {
+    const deviceStatus = await getDeviceStatus(db, deviceName);
+    if (!deviceStatus) {
       return c.json({ error: "Device Not Found" }, 404);
     }
 
-    const baseStatus = await getHeartbeatStatus(db, deviceName);
-    if (!baseStatus) {
-      return c.json({ error: "Status Not Available" }, 500);
-    }
-
-    return c.json(enrichStatus(baseStatus));
+    return c.json(deviceStatus);
   });
 
 export default status;

--- a/worker/src/app/devices/details.tsx
+++ b/worker/src/app/devices/details.tsx
@@ -1,5 +1,8 @@
 import { getDeviceByName } from "../../services/devices";
-import { enrichStatus, getHeartbeatStatus } from "../../services/heartbeats";
+import {
+  getLatestHeartbeatByDeviceId,
+  resolveDeviceStatus,
+} from "../../services/heartbeats";
 import honoFactory from "../../services/honoFactory";
 import { getDeviceReportRows, toReportItems } from "../../services/reports";
 import { deviceDetailsPage } from "../../ui/pages/devices/details";
@@ -34,21 +37,16 @@ const app = honoFactory.createApp().get("/:device", async (c) => {
     });
   }
 
-  const [baseStatus, reportRows] = await Promise.all([
-    getHeartbeatStatus(db, device.name),
+  const [latest, reportRows] = await Promise.all([
+    getLatestHeartbeatByDeviceId(db, device.id),
     getDeviceReportRows(db, device.id),
   ]);
-  if (!baseStatus) {
-    return c.render(<NotFound name={deviceName} />, {
-      title: "デバイスが見つかりません",
-    });
-  }
 
   return renderPage(
     c,
     deviceDetailsPage,
     {
-      status: enrichStatus(baseStatus),
+      status: resolveDeviceStatus(device, latest),
       reports: toReportItems(reportRows),
     },
     { title: device.name },

--- a/worker/src/services/heartbeats.ts
+++ b/worker/src/services/heartbeats.ts
@@ -4,7 +4,7 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { heartbeatConfig } from "../config";
 import * as schema from "../db/schema";
 import type { status } from "../types";
-import { getDeviceByName, getDevices } from "./devices";
+import type { Device } from "./devices";
 
 type DB = DrizzleD1Database<typeof schema>;
 
@@ -21,56 +21,6 @@ export async function getLatestHeartbeatByDeviceId(
   });
 }
 
-export interface HeartbeatStatus {
-  device: string;
-  status: status;
-  lastLogAt: string;
-}
-
-export async function getHeartbeatStatus(
-  db: DB,
-  deviceName: string,
-): Promise<HeartbeatStatus | undefined> {
-  const device = await getDeviceByName(db, deviceName);
-  if (!device) return undefined;
-
-  const latest = await getLatestHeartbeatByDeviceId(db, device.id);
-
-  if (!latest) {
-    return {
-      device: deviceName,
-      status: "pending",
-      lastLogAt: "",
-    };
-  }
-
-  const latestTime = new Date(latest.createdAt);
-  const now = new Date();
-  const diffSeconds = Math.floor((now.getTime() - latestTime.getTime()) / 1000);
-
-  if (diffSeconds > heartbeatConfig.errorThresholdMinutes * 60) {
-    return {
-      device: deviceName,
-      status: "error",
-      lastLogAt: latest.createdAt,
-    };
-  }
-
-  if (diffSeconds > heartbeatConfig.warnThresholdMinutes * 60) {
-    return {
-      device: deviceName,
-      status: "warn",
-      lastLogAt: latest.createdAt,
-    };
-  }
-
-  return {
-    device: deviceName,
-    status: "ok",
-    lastLogAt: latest.createdAt,
-  };
-}
-
 /**
  * 画面と API が共有するデバイスの状態。
  * サーバーサイドレンダリングとクライアントのポーリングが同じ形を扱うため、
@@ -80,33 +30,62 @@ export interface DeviceStatus {
   device: string;
   status: status;
   lastLogAt: string;
+  /** pending は基準時刻が無いので省略される */
   timeSinceLastLogSeconds?: number;
 }
 
-/** 最終ログからの経過秒数を足す。pending は基準時刻が無いので省略する。 */
-export function enrichStatus(baseStatus: HeartbeatStatus): DeviceStatus {
-  const { device, status, lastLogAt } = baseStatus;
+/** デバイスと、その最新ハートビート1件 */
+type DeviceWithLatestHeartbeat = Device & { heartbeats: Heartbeat[] };
 
-  if (status === "pending") {
-    return {
-      device,
-      status,
-      lastLogAt,
-    };
+/**
+ * 最新ハートビートからステータスを判定する。
+ * 閾値判定の唯一の実装。クエリを持たない純粋関数なので、
+ * 一括取得と単体取得のどちらからも同じ結果になる。
+ */
+export function resolveDeviceStatus(
+  device: Device,
+  latest: Heartbeat | undefined,
+): DeviceStatus {
+  const { name } = device;
+
+  if (!latest) {
+    return { device: name, status: "pending", lastLogAt: "" };
   }
 
-  const latestTime = new Date(lastLogAt);
-  const now = new Date();
   const timeSinceLastLogSeconds = Math.floor(
-    (now.getTime() - latestTime.getTime()) / 1000,
+    (Date.now() - new Date(latest.createdAt).getTime()) / 1000,
   );
 
+  const value: status =
+    timeSinceLastLogSeconds > heartbeatConfig.errorThresholdMinutes * 60
+      ? "error"
+      : timeSinceLastLogSeconds > heartbeatConfig.warnThresholdMinutes * 60
+        ? "warn"
+        : "ok";
+
   return {
-    device,
-    status,
-    lastLogAt,
+    device: name,
+    status: value,
+    lastLogAt: latest.createdAt,
     timeSinceLastLogSeconds,
   };
+}
+
+/**
+ * 全デバイスと最新ハートビート1件を1クエリで取得する。
+ * drizzle が相関サブクエリで包むため limit はデバイスごとに適用される。
+ */
+export async function getDevicesWithLatestHeartbeat(
+  db: DB,
+): Promise<DeviceWithLatestHeartbeat[]> {
+  return db.query.devices.findMany({
+    with: {
+      heartbeats: {
+        orderBy: [desc(schema.heartbeats.createdAt)],
+        limit: 1,
+      },
+    },
+  });
 }
 
 /**
@@ -115,12 +94,30 @@ export function enrichStatus(baseStatus: HeartbeatStatus): DeviceStatus {
  * 実装が分かれると出力がずれ、クライアントへの引き継ぎ時に表示がちらつく。
  */
 export async function getDeviceStatuses(db: DB): Promise<DeviceStatus[]> {
-  const devices = await getDevices(db);
-  return (
-    await Promise.all(
-      devices.map((device) => getHeartbeatStatus(db, device.name)),
-    )
-  )
-    .filter((s): s is NonNullable<typeof s> => !!s)
-    .map(enrichStatus);
+  const devices = await getDevicesWithLatestHeartbeat(db);
+  return devices.map(({ heartbeats, ...device }) =>
+    resolveDeviceStatus(device, heartbeats.at(0)),
+  );
+}
+
+/** 単体版。デバイスが存在しない場合は undefined */
+export async function getDeviceStatus(
+  db: DB,
+  deviceName: string,
+): Promise<DeviceStatus | undefined> {
+  const found = await db.query.devices.findFirst({
+    where: eq(schema.devices.name, deviceName),
+    with: {
+      heartbeats: {
+        orderBy: [desc(schema.heartbeats.createdAt)],
+        limit: 1,
+      },
+    },
+  });
+  if (!found) {
+    return undefined;
+  }
+
+  const { heartbeats, ...device } = found;
+  return resolveDeviceStatus(device, heartbeats.at(0));
 }

--- a/worker/src/services/reports.ts
+++ b/worker/src/services/reports.ts
@@ -4,8 +4,10 @@ import type { DrizzleD1Database } from "drizzle-orm/d1";
 import * as schema from "../db/schema";
 import type { status } from "../types";
 import type { Device } from "./devices";
-import { getDevices } from "./devices";
-import { getHeartbeatStatus } from "./heartbeats";
+import {
+  getDevicesWithLatestHeartbeat,
+  resolveDeviceStatus,
+} from "./heartbeats";
 
 type DB = DrizzleD1Database<typeof schema>;
 
@@ -116,21 +118,20 @@ export async function updateAllDevicesReports(
   db: DB,
   callback?: StatusChangeCallback,
 ) {
-  const devices = await getDevices(db);
+  // デバイスと最新ハートビートを1クエリで取る
+  const devices = await getDevicesWithLatestHeartbeat(db);
   // 各deviceのステータスをチェックし、変更があればreportsに保存
   await Promise.all(
-    devices.map(async (device) => {
-      const status = await getHeartbeatStatus(db, device.name);
-      if (status) {
-        const saved = await saveReportIfStatusChanged(
-          db,
-          device,
-          status.status,
-          callback,
-        );
-        if (saved) {
-          console.log(`Status changed for ${device.name}: ${status.status}`);
-        }
+    devices.map(async ({ heartbeats, ...device }) => {
+      const status = resolveDeviceStatus(device, heartbeats.at(0));
+      const saved = await saveReportIfStatusChanged(
+        db,
+        device,
+        status.status,
+        callback,
+      );
+      if (saved) {
+        console.log(`Status changed for ${device.name}: ${status.status}`);
       }
     }),
   );


### PR DESCRIPTION
## 背景

`getHeartbeatStatus` はデバイス**名**しか受け取らないため、呼び出し元が既に `Device` を持っていても内部で `getDeviceByName` を引き直していました。

```ts
export async function getDeviceStatuses(db: DB) {
  const devices = await getDevices(db);          // ← Device を持っている
  return Promise.all(
    devices.map((device) => getHeartbeatStatus(db, device.name)),  // ← 名前だけ渡す
  );
}

export async function getHeartbeatStatus(db, deviceName) {
  const device = await getDeviceByName(db, deviceName);  // ← 引き直す
```

手元にあるデータを取り直すだけのクエリが N 本走っていました。一覧しか無かった時期の名残で、単体取得の API が用意されていなかったのが発端です。

## 変更

全件取得と単体取得を揃え、**どちらも1クエリ**にしました。

```ts
getDeviceStatuses(db)              // 全件
getDeviceStatus(db, deviceName)    // 単体
```

いずれも drizzle のリレーショナルクエリで最新ハートビート1件を同時に取得します。`limit` は相関サブクエリでデバイスごとに適用され（#14 で検証済みのパターン）、`heartbeats_device_id_created_at_idx` がそのまま効きます。

閾値判定は `resolveDeviceStatus(device, latest)` という純粋関数に切り出し、**一覧・単体・cron の3経路で共有**します。実装が分かれると同じデバイスが経路によって別のステータスになりうるためです。

## 実測（デバイス4台）

`env.DB.prepare` を差し替えて実際に発行される SQL を数えました。

| | 変更前 | 変更後 |
| --- | ---: | ---: |
| `GET /` | 10 | **2** |
| `GET /api/status` | 9 | **1** |
| `GET /devices/:name` | 4 | **3** |

1分ごとに走る cron（`updateAllDevicesReports`）も `1 + 2N` → **1クエリ**になりました。

なお `Promise.all` で並列化されていたため、**待ち時間はもともと N に比例していません**でした（逐次3ホップ）。今回の効果は「クエリ数（D1 の読み取り課金と上限）」と「逐次ホップ数 3 → 1」です。レイテンシの改善は往復2回ぶんで、劇的なものではありません。

## 削除した API

`getHeartbeatStatus` / `enrichStatus` / `HeartbeatStatus` を削除しました（参照は0件）。

| 削除 | 役割 | 移った先 |
| --- | --- | --- |
| `getHeartbeatStatus` | 名前でデバイスを引く → 最新ハートビート → 閾値判定 | `getDeviceStatus`（1クエリ）と `resolveDeviceStatus`（判定のみ）に分割 |
| `enrichStatus` | 経過秒数を後付け | `resolveDeviceStatus` に統合。判定と同時に計算する |
| `HeartbeatStatus` | 経過秒数を持たない中間型 | 廃止。全経路が `DeviceStatus` を返す |

`enrichStatus` と `HeartbeatStatus` は「まず判定して、あとから経過秒数を足す」2段構えのための存在でした。呼び出し元が毎回 `enrichStatus(await getHeartbeatStatus(...))` と書く必要があり、**書き忘れると `timeSinceLastLogSeconds` が欠けたレスポンスになりえます**。1関数にまとめたのでその余地がなくなりました。

変更後の `src/services/heartbeats.ts` の export は次のとおりです。

```ts
Heartbeat                       型
DeviceStatus                    型（画面と API が共有する唯一の形）
getLatestHeartbeatByDeviceId    最新1件だけ欲しいとき
resolveDeviceStatus             閾値判定の純粋関数（クエリなし）
getDevicesWithLatestHeartbeat   全デバイス＋最新1件を1クエリ
getDeviceStatuses               全件
getDeviceStatus                 単体
```

`getLatestHeartbeatByDeviceId` を残しているのは詳細ページのためです。あそこは `getDeviceByName` で既に `Device` を持っているので、`getDeviceStatus` を使うとデバイスを引き直してしまいます。`resolveDeviceStatus(device, latest)` と組み合わせる形にしました。

`getDevicesWithLatestHeartbeat` を export しているのは cron（`updateAllDevicesReports`）が `Device` の id を必要とするからです。`getDeviceStatuses` は `DeviceStatus[]` を返し id を持ちません。

## あわせて

`GET /api/status/:device` の 500 `"Status Not Available"` 分岐を削除しました。直前の `getDeviceByName` が存在確認を済ませており、到達しない死んだ分岐でした。404 の挙動は変わりません（テストも既存のまま通ります）。

## テスト

**複数ハートビートを持つデバイスで「最新の1件」が選ばれること**を一覧・単体の両方で検証するテストを追加しました。今回の変更で最も壊れやすい箇所ですが、既存テストは複数件ある状態を作っていませんでした。挿入順ではなく `created_at` で選ぶことを確かめるため、わざと新しい順に入れていません。

既存テストは1つも変更していません（レスポンス形状は不変）。48 tests 通過、lint / tsc も green です。

## 残っている申し送り

`/devices/:name` が3クエリなのは `getDeviceByName` → `[最新ハートビート, レポート]` の並列という形のためです。1クエリにまとめることも可能ですが、レポート取得は `GET /api/reports/:device` とクエリを共有してドリフトを防いでいる（#14）ので、そこを崩してまで詰める価値は薄いと判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * デバイスのステータス判定を最新のハートビートに基づいて統一しました。
  * デバイス一覧・詳細画面で、最新のハートビートが正しく表示されるようになりました。
  * 最新ログからの経過時間をステータス情報として表示できるようになりました。
  * ハートビートが保留中の場合、不要な経過時間を表示しないよう改善しました。

* **バグ修正**
  * 複数のハートビートがある場合に、古い情報が選択される問題を修正しました。
  * ステータス変更時のレポート記録を、最新情報に基づいて正しく行うよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
